### PR TITLE
Adds video & artist name content to /catalogue

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -35,3 +35,15 @@ $('.eventsInfoBox').find(`p`).addClass('hidden');
 $('.eventsInfoBox').find(`${eventToShow}`).removeClass('hidden');
 
 });
+
+// ------------------------------- video functions ----------
+
+let video = $('.video')
+
+function play() {
+  video.play()
+}
+
+function pause() {
+  video.pause()
+}

--- a/server.js
+++ b/server.js
@@ -48,15 +48,44 @@ app.get('/', function(req, res) {
   });
 });
 
+function compare(a, b) {
+    var splitA = a.split(" ");
+    var splitB = b.split(" ");
+    var lastA = splitA[splitA.length - 1];
+    var lastB = splitB[splitB.length - 1];
+
+    if (lastA < lastB) return -1;
+    if (lastA > lastB) return 1;
+    return 0;
+}
+
 // placeholders for eventresults and catalogueResults returned from database/cms
 
 app.get('/catalogue', function(req, res) {
-  //need client.getEntries for artists names / essays
-  res.render('catalogue', {
-    layout: 'layout'
-    // artists: artistsResults,
-    // essays: essaysResults
-  });
+
+  client.getEntries().then((entries) => {
+    let artists = [];
+    let video;
+
+    entries.items.forEach(entry=> {
+      if (entry.fields.artistName) {
+        artists.push(entry.fields.artistName)
+      } else if (entry.fields.video) {
+        video = entry.fields.video.fields.file.url.replace('//', '')
+      }
+    })
+
+    artists.sort(compare);
+    console.log(video);
+
+    res.render('catalogue', {
+      layout: 'layout',
+      artists: artists,
+      video: video
+    });
+  }).catch((err) => {
+    console.log('err: ', err)
+  })
 });
 
 

--- a/views/catalogue.handlebars
+++ b/views/catalogue.handlebars
@@ -4,7 +4,7 @@
 
 <div id="catalogue-artists-purple">
   {{#artists}}
-  <p>{{firstname lastname}}</p>
+  <p>{{.}}</p>
   {{/artists}}
 
   <img src="/assets/Elements/DriveDrive/Catalogue/DD-Catalogue-artists-purple.svg">
@@ -24,9 +24,11 @@
   <img id="catalogue-line-blue" src="/assets/Elements/DriveDrive/Catalogue/DD-Catalogue-line-blue.svg">
 
 
-  <div class="video">
+  <div class="video-container">
     {{#video}}
-    <iframe src="" width="300px" height="400px"></iframe>
+    <video class='video' height="240" width="400" onmouseover="pause()" onmouseleave="play()" autoplay controls>
+      <source src={{.}} type="video/mp4">
+    </video>
     {{/video}}
     <img id="catalogue-video-grey" src="/assets/Elements/DriveDrive/Catalogue/DD-Catalogue-video-grey.svg">
   </div>


### PR DESCRIPTION
I added functions that enable the pause/play functionality
to the video when mouseover/mouseleave happens, respectively.
However, the video is not showing up, so I will be working
to debug that.

Also, the artist names are showing up, though not spaced
correctly. This is probably just a stylistic issue though.
TBD.